### PR TITLE
Rm support for python<3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,10 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     url='https://github.com/anexia-it/geofeed-validator'


### PR DESCRIPTION
Rm support for python<3.5 to be able to update dependencies properly and get a github actions pipeline running.