### PR TITLE
Use iso-code 4.5.0 via pycountries update, rm compatibility code for old pycountry versions

### DIFF
--- a/geofeed_validator/fields/base.py
+++ b/geofeed_validator/fields/base.py
@@ -138,10 +138,7 @@ class CountryField(Field):
 
     def _check_errors(self, value):
         if value:
-            try:
-                if not self.to_python(value):
-                    return True
-            except:
+            if not self.to_python(value):
                 return True
         return False
 
@@ -166,10 +163,7 @@ class SubdivisionField(Field):
 
     def _check_errors(self, value):
         if value:
-            try:
-                if not self.to_python(value):
-                    return True
-            except:
+            if not self.to_python(value):
                 return True
         return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pycountry>=16.11.27.1
+pycountry>=20.7.3
 netaddr>=0.7.11


### PR DESCRIPTION
This MR updates pycountries dependency.
Therefore we can remove some compatibility code for older versions and enforce following iso-code 4.5.0.