### PR TITLE
Add release notes and version change for upcoming 0.6.0 release

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,0 +1,10 @@
+Changelog
+*********
+
+0.6.0
+-----
+* Add support for latest pycountry (https://github.com/anexia-it/geofeed-validator/issues/4, thanks vangesseld)
+* Add support for Python 3.5, 3.6, 3.7, 3.8, 3.9
+* Drop support for Python 2
+* Drop support for Python 3.2, 3.3, 3.4
+* Update requirements to follow iso-codes 4.5.0

--- a/geofeed_validator/__init__.py
+++ b/geofeed_validator/__init__.py
@@ -30,7 +30,7 @@ import io
 from geofeed_validator.utils import is_file_like_object
 from geofeed_validator.validator.base import BaseValidator, Registry
 
-__version__ = '0.5.1'
+__version__ = '0.6.0'
 
 
 class GeoFeedValidator(object):


### PR DESCRIPTION
This MR updates pycountries dependency.
Therefore we can remove some compatibility code for older versions and enforce following iso-code 4.5.0.