### PR TITLE
Update for netaddr 1.0.0

### DIFF
--- a/geofeed_validator/fields/base.py
+++ b/geofeed_validator/fields/base.py
@@ -115,6 +115,7 @@ class NetworkField(Field):
     ERROR_PRIVATE = "Private network not allowed"
     ERROR_RESERVED = "Reserved network not allowed"
     ERROR_MULTICAST = "Multicast network not allowed"
+    ERROR_LINKLOCAL = "Link-local network not allowed"
     NAME = "network"
 
     def _check_errors(self, value):
@@ -124,10 +125,16 @@ class NetworkField(Field):
         except:
             return True
 
+        ip = netaddr.IPAddress(net.network)
+
         if net.is_loopback():
             return self.ERROR_LOOPBACK
-        elif net.is_private():
+        elif ip.is_ipv4_private_use():
             return self.ERROR_PRIVATE
+        elif ip.is_ipv6_unique_local():
+            return self.ERROR_PRIVATE
+        elif ip.is_link_local():
+            return self.ERROR_LINKLOCAL
         elif net.is_reserved():
             return self.ERROR_RESERVED
         elif net.is_multicast():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.6.2,<4"
 pycountry = ">=20.7.3"
-netaddr = ">=0.8.0"
+netaddr = ">=1.0.0"
 
 [tool.poetry.dev-dependencies]
 coverage = ">=5.5.0"


### PR DESCRIPTION
netaddr 1.0.0 makes removes the is_private method which breaks geofeed_validator.
See https://netaddr.readthedocs.io/en/latest/changes.html#release-1-0-0

There are new methods that cover that in the IPAddress object (not the net object) so I've created a fix here, and bumped the required netaddr version to 1.0.0 so it gets the correct version.